### PR TITLE
Feed domain name from hostname fqdn when possible.

### DIFF
--- a/Machine.cpp
+++ b/Machine.cpp
@@ -613,6 +613,14 @@ Machine::_GetOSInfo()
 	fKernelInfo.domain_name = uName.domainname;
 	fKernelInfo.machine = uName.machine;
 
+	//Feed domain name from host name when possible.
+	if (fKernelInfo.domain_name=="" || fKernelInfo.domain_name=="(none)") {
+                size_t dotPos = fKernelInfo.hostname.find('.');
+                if (dotPos != std::string::npos) {
+                        fKernelInfo.domain_name = fKernelInfo.hostname.substr(dotPos+1);
+                }
+        }
+
 	ProcReader proc("/proc/meminfo");
 	std::istream stream(&proc);
 


### PR DESCRIPTION
In some configuration the command domainname didn't return the expected result but the domain can be deducted from the hostname command : 
```
[user@host agent]$ domainname
(none)
[user@host agent]$ hostname
host.domain.name
```
For that case, a minor change can do the trick.