### PR TITLE
Feed OS from /etc/redhat-release when possible.

### DIFF
--- a/Machine.cpp
+++ b/Machine.cpp
@@ -668,8 +668,13 @@ Machine::_OSDescription()
 		// try to identify the system in another way
 		if (::access("/etc/thinstation.global", F_OK) != -1)
 			osDescription = "Thinstation";
-		else
+		else {
+			try {
+                                osDescription = trimmed(ProcReader("/etc/redhat-release").ReadLine());
+                        } catch (...) {
 			osDescription = "Unknown";
+			}
+		}
 	}
 	
 	return osDescription;


### PR DESCRIPTION
works great for Redhat, Centos and Fedora
Report OS and version like this :  (for exemple)
 OS Name:	CentOS Linux release 7.3.1611 (Core)